### PR TITLE
Add Accounts.urls property with URLS interface

### DIFF
--- a/1.2/packages/accounts-base.d.ts
+++ b/1.2/packages/accounts-base.d.ts
@@ -1,6 +1,13 @@
 /// <reference path="meteor.d.ts" />
+interface URLS {
+  resetPassword: (token:string) => string;
+  verifyEmail:  (token:string) => string;
+  enrollAccount: (token:string) => string;
+}
 
 declare module Accounts {
+  var urls: URLS;
+
   function user(): Meteor.User;
   function userId(): string;
 


### PR DESCRIPTION
URLS interface holds functions that return urls for resetPassword,
verifyEmail and enrollAccount. Using these typings these functions can be
overridden to provide custom urls.

Example:

````  
// override enroll url
Accounts.urls.enrollAccount = function(token: string) {
  return Meteor.absoluteUrl('enroll-account/' + token);
}
````