### PR TITLE
Add Mongo.Collection._dropIndex and Meteor.isDevelopment with tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+out/

--- a/1.2/browser.d.ts
+++ b/1.2/browser.d.ts
@@ -527,7 +527,7 @@ declare module Meteor {
     redirectUrl?: string;
   }, callback?: Function): void;
   function loginWithPassword(user: Object | string, password: string, callback?: Function): void;
-  function loginWithToken(token:string, callback?: Function): void;
+  function loginWithToken(token: string, callback?: Function): void;
   function logout(callback?: Function): void;
   function logoutOtherClients(callback?: Function): void;
   /** Login **/

--- a/1.2/browser.d.ts
+++ b/1.2/browser.d.ts
@@ -1,6 +1,13 @@
 /// <reference path="meteor.d.ts" />
+interface URLS {
+  resetPassword: (token:string) => string;
+  verifyEmail:  (token:string) => string;
+  enrollAccount: (token:string) => string;
+}
 
 declare module Accounts {
+  var urls: URLS;
+
   function user(): Meteor.User;
   function userId(): string;
 
@@ -520,7 +527,6 @@ declare module Meteor {
     redirectUrl?: string;
   }, callback?: Function): void;
   function loginWithPassword(user: Object | string, password: string, callback?: Function): void;
-  function loginWithToken(token:string, callback ? : Function): void;
   function logout(callback?: Function): void;
   function logoutOtherClients(callback?: Function): void;
   /** Login **/
@@ -648,6 +654,7 @@ declare module Mongo {
       multi?: boolean;
     }, callback?: Function): { numberAffected?: number; insertedId?: string; };
     _ensureIndex(keys: { [key: string]: number | string } | string, options?: { [key: string]: any }): void;
+    _dropIndex(keys: { [key: string]: number | string } | string): void;
   }
 
   var Cursor: CursorStatic;

--- a/1.2/browser.d.ts
+++ b/1.2/browser.d.ts
@@ -527,6 +527,7 @@ declare module Meteor {
     redirectUrl?: string;
   }, callback?: Function): void;
   function loginWithPassword(user: Object | string, password: string, callback?: Function): void;
+  function loginWithToken(token:string, callback?: Function): void;
   function logout(callback?: Function): void;
   function logoutOtherClients(callback?: Function): void;
   /** Login **/

--- a/1.2/main.d.ts
+++ b/1.2/main.d.ts
@@ -527,7 +527,7 @@ declare module Meteor {
     redirectUrl?: string;
   }, callback?: Function): void;
   function loginWithPassword(user: Object | string, password: string, callback?: Function): void;
-  function loginWithToken(token:string, callback?: Function): void;
+  function loginWithToken(token: string, callback?: Function): void;
   function logout(callback?: Function): void;
   function logoutOtherClients(callback?: Function): void;
   /** Login **/

--- a/1.2/main.d.ts
+++ b/1.2/main.d.ts
@@ -1,6 +1,13 @@
 /// <reference path="meteor.d.ts" />
+interface URLS {
+  resetPassword: (token:string) => string;
+  verifyEmail:  (token:string) => string;
+  enrollAccount: (token:string) => string;
+}
 
 declare module Accounts {
+  var urls: URLS;
+
   function user(): Meteor.User;
   function userId(): string;
 
@@ -520,7 +527,6 @@ declare module Meteor {
     redirectUrl?: string;
   }, callback?: Function): void;
   function loginWithPassword(user: Object | string, password: string, callback?: Function): void;
-  function loginWithToken(token:string, callback ? : Function): void;
   function logout(callback?: Function): void;
   function logoutOtherClients(callback?: Function): void;
   /** Login **/
@@ -648,6 +654,7 @@ declare module Mongo {
       multi?: boolean;
     }, callback?: Function): { numberAffected?: number; insertedId?: string; };
     _ensureIndex(keys: { [key: string]: number | string } | string, options?: { [key: string]: any }): void;
+    _dropIndex(keys: { [key: string]: number | string } | string): void;
   }
 
   var Cursor: CursorStatic;

--- a/1.2/main.d.ts
+++ b/1.2/main.d.ts
@@ -527,6 +527,7 @@ declare module Meteor {
     redirectUrl?: string;
   }, callback?: Function): void;
   function loginWithPassword(user: Object | string, password: string, callback?: Function): void;
+  function loginWithToken(token:string, callback?: Function): void;
   function logout(callback?: Function): void;
   function logoutOtherClients(callback?: Function): void;
   /** Login **/

--- a/1.2/packages/meteor_browser.d.ts
+++ b/1.2/packages/meteor_browser.d.ts
@@ -28,6 +28,7 @@ declare module Meteor {
     redirectUrl?: string;
   }, callback?: Function): void;
   function loginWithPassword(user: Object | string, password: string, callback?: Function): void;
+  function loginWithToken(token:string, callback?: Function): void;
   function logout(callback?: Function): void;
   function logoutOtherClients(callback?: Function): void;
   /** Login **/

--- a/1.2/packages/meteor_browser.d.ts
+++ b/1.2/packages/meteor_browser.d.ts
@@ -28,7 +28,7 @@ declare module Meteor {
     redirectUrl?: string;
   }, callback?: Function): void;
   function loginWithPassword(user: Object | string, password: string, callback?: Function): void;
-  function loginWithToken(token:string, callback?: Function): void;
+  function loginWithToken(token: string, callback?: Function): void;
   function logout(callback?: Function): void;
   function logoutOtherClients(callback?: Function): void;
   /** Login **/

--- a/1.2/packages/mongo.d.ts
+++ b/1.2/packages/mongo.d.ts
@@ -59,6 +59,7 @@ declare module Mongo {
       multi?: boolean;
     }, callback?: Function): { numberAffected?: number; insertedId?: string; };
     _ensureIndex(keys: { [key: string]: number | string } | string, options?: { [key: string]: any }): void;
+    _dropIndex(keys: { [key: string]: number | string } | string): void;
   }
 
   var Cursor: CursorStatic;

--- a/1.3/browser.d.ts
+++ b/1.3/browser.d.ts
@@ -1,6 +1,13 @@
 /// <reference path="meteor.d.ts" />
+interface URLS {
+  resetPassword: (token: string) => string;
+  verifyEmail: (token: string) => string;
+  enrollAccount: (token: string) => string;
+}
 
 declare module Accounts {
+  var urls: URLS;
+
   function user(): Meteor.User;
 
   function userId(): string;
@@ -35,8 +42,15 @@ declare module Accounts {
 
 declare module "meteor/accounts-base" {
   /// <reference path="meteor.d.ts" />
+  interface URLS {
+    resetPassword: (token: string) => string;
+    verifyEmail: (token: string) => string;
+    enrollAccount: (token: string) => string;
+  }
 
   module Accounts {
+    var urls: URLS;
+
     function user(): Meteor.User;
 
     function userId(): string;
@@ -1166,8 +1180,6 @@ declare module Meteor {
 
   function loginWithPassword(user: Object | string, password: string, callback ? : Function): void;
 
-  function loginWithToken(token:string, callback ? : Function): void;
-
   function logout(callback ? : Function): void;
 
   function logoutOtherClients(callback ? : Function): void;
@@ -1416,6 +1428,9 @@ declare module Mongo {
     } | string, options ? : {
       [key: string]: any
     }): void;
+    _dropIndex(keys: {
+      [key: string]: number | string
+    } | string): void;
   }
 
   var Cursor: CursorStatic;
@@ -1522,6 +1537,9 @@ declare module "meteor/mongo" {
       } | string, options ? : {
         [key: string]: any
       }): void;
+      _dropIndex(keys: {
+        [key: string]: number | string
+      } | string): void;
     }
 
     var Cursor: CursorStatic;
@@ -1823,5 +1841,18 @@ declare module "meteor/tracker" {
     function nonreactive(func: Function): void;
 
     function onInvalidate(callback: Function): void;
+  }
+}
+declare module Meteor {
+  /** Global props **/
+  var isDevelopment: boolean;
+  /** Global props **/
+}
+
+declare module "meteor/meteor" {
+  module Meteor {
+    /** Global props **/
+    var isDevelopment: boolean;
+    /** Global props **/
   }
 }

--- a/1.3/browser.d.ts
+++ b/1.3/browser.d.ts
@@ -1180,6 +1180,8 @@ declare module Meteor {
 
   function loginWithPassword(user: Object | string, password: string, callback ? : Function): void;
 
+  function loginWithToken(token: string, callback ? : Function): void;
+
   function logout(callback ? : Function): void;
 
   function logoutOtherClients(callback ? : Function): void;
@@ -1262,6 +1264,8 @@ declare module "meteor/meteor" {
     }, callback ? : Function): void;
 
     function loginWithPassword(user: Object | string, password: string, callback ? : Function): void;
+
+    function loginWithToken(token: string, callback ? : Function): void;
 
     function logout(callback ? : Function): void;
 

--- a/1.3/main.d.ts
+++ b/1.3/main.d.ts
@@ -1,6 +1,13 @@
 /// <reference path="meteor.d.ts" />
+interface URLS {
+  resetPassword: (token: string) => string;
+  verifyEmail: (token: string) => string;
+  enrollAccount: (token: string) => string;
+}
 
 declare module Accounts {
+  var urls: URLS;
+
   function user(): Meteor.User;
 
   function userId(): string;
@@ -35,8 +42,15 @@ declare module Accounts {
 
 declare module "meteor/accounts-base" {
   /// <reference path="meteor.d.ts" />
+  interface URLS {
+    resetPassword: (token: string) => string;
+    verifyEmail: (token: string) => string;
+    enrollAccount: (token: string) => string;
+  }
 
   module Accounts {
+    var urls: URLS;
+
     function user(): Meteor.User;
 
     function userId(): string;
@@ -1166,8 +1180,6 @@ declare module Meteor {
 
   function loginWithPassword(user: Object | string, password: string, callback ? : Function): void;
 
-  function loginWithToken(token:string, callback ? : Function): void;
-
   function logout(callback ? : Function): void;
 
   function logoutOtherClients(callback ? : Function): void;
@@ -1416,6 +1428,9 @@ declare module Mongo {
     } | string, options ? : {
       [key: string]: any
     }): void;
+    _dropIndex(keys: {
+      [key: string]: number | string
+    } | string): void;
   }
 
   var Cursor: CursorStatic;
@@ -1522,6 +1537,9 @@ declare module "meteor/mongo" {
       } | string, options ? : {
         [key: string]: any
       }): void;
+      _dropIndex(keys: {
+        [key: string]: number | string
+      } | string): void;
     }
 
     var Cursor: CursorStatic;
@@ -2027,5 +2045,18 @@ declare module "meteor/tracker" {
     function nonreactive(func: Function): void;
 
     function onInvalidate(callback: Function): void;
+  }
+}
+declare module Meteor {
+  /** Global props **/
+  var isDevelopment: boolean;
+  /** Global props **/
+}
+
+declare module "meteor/meteor" {
+  module Meteor {
+    /** Global props **/
+    var isDevelopment: boolean;
+    /** Global props **/
   }
 }

--- a/1.3/main.d.ts
+++ b/1.3/main.d.ts
@@ -1180,6 +1180,8 @@ declare module Meteor {
 
   function loginWithPassword(user: Object | string, password: string, callback ? : Function): void;
 
+  function loginWithToken(token: string, callback ? : Function): void;
+
   function logout(callback ? : Function): void;
 
   function logoutOtherClients(callback ? : Function): void;
@@ -1262,6 +1264,8 @@ declare module "meteor/meteor" {
     }, callback ? : Function): void;
 
     function loginWithPassword(user: Object | string, password: string, callback ? : Function): void;
+
+    function loginWithToken(token: string, callback ? : Function): void;
 
     function logout(callback ? : Function): void;
 

--- a/1.3/packages/meteor.d.ts
+++ b/1.3/packages/meteor.d.ts
@@ -1,0 +1,5 @@
+declare module Meteor {
+  /** Global props **/
+  var isDevelopment: boolean;
+  /** Global props **/
+}

--- a/1.3/test/test.ts
+++ b/1.3/test/test.ts
@@ -706,3 +706,9 @@ const username = (<HTMLInputElement> Template.instance().find('#username')).valu
 // Covers https://github.com/meteor-typings/meteor/issues/3
 BrowserPolicy.framing.disallow();
 BrowserPolicy.content.allowEval();
+
+
+// Covers https://github.com/meteor-typings/meteor/issues/18
+if (Meteor.isDevelopment) {
+  Rooms._dropIndex({field: 1});
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,18 +50,18 @@ function performChange(content) {
       content, fname, newContent), {
     indent_size: 2,
     indent_char: " "
-  }).replace(/declare\n/g, "declare ");
+  }).replace(/declare\r?\n/g, "declare ");
 }
 
 gulp.task("prep_1_3_main", function() {
-  return gulp.src(["./1.2/packages/*.ts"])
+  return gulp.src(["./1.2/packages/*.ts", "./1.3/packages/*.ts"])
     .pipe(change(performChange))
     .pipe(concat('main.d.ts'))
     .pipe(gulp.dest("1.3/"));
 });
 
 gulp.task("prep_1_3_browser", function() {
-  return gulp.src(["./1.2/packages/*.ts"])
+  return gulp.src(["./1.2/packages/*.ts", "./1.3/packages/*.ts"])
     .pipe(ignore('*tools_main.d.ts'))
     .pipe(change(performChange))
     .pipe(concat('browser.d.ts'))


### PR DESCRIPTION
- Add `Mongo.Collection._dropIndex` and `Meteor.isDevelopment` with tests
- Make gulp work well on Windows
- Make gulp read `1.3/packages/*.ts`
- Add .gitignore to ignore unwanted node and tsc files
- Regenerate main.d.ts and browser.d.ts with gulp
(as a result, they include changes of c766810eae2250ccd8ce7e0fb718ce433bee58bc)
- Add `loginWithPassword` in `1.2/packages/meteor_browser.d.ts` for 640e596dfa3c2fce42550e4bef2030d6ad4b7ab5