### PR TITLE
Add applySkipLimit option in count method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 *.log
-out
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 *.log
-out/
+out

--- a/1.2/browser.d.ts
+++ b/1.2/browser.d.ts
@@ -679,7 +679,7 @@ declare module Mongo {
     removed?(id: string): void;
   }
   interface Cursor<T> {
-    count(): number;
+    count(applySkipLimit?: boolean): number;
     fetch(): Array<T>;
     forEach(callback: <T>(doc: T, index: number, cursor: Cursor<T>) => void, thisArg?: any): void;
     map<U>(callback: (doc: T, index: number, cursor: Cursor<T>) => U, thisArg?: any): Array<U>;

--- a/1.2/main.d.ts
+++ b/1.2/main.d.ts
@@ -679,7 +679,7 @@ declare module Mongo {
     removed?(id: string): void;
   }
   interface Cursor<T> {
-    count(): number;
+    count(applySkipLimit?: boolean): number;
     fetch(): Array<T>;
     forEach(callback: <T>(doc: T, index: number, cursor: Cursor<T>) => void, thisArg?: any): void;
     map<U>(callback: (doc: T, index: number, cursor: Cursor<T>) => U, thisArg?: any): Array<U>;

--- a/1.2/packages/mongo.d.ts
+++ b/1.2/packages/mongo.d.ts
@@ -83,7 +83,7 @@ declare module Mongo {
     removed?(id: string): void;
   }
   interface Cursor<T> {
-    count(): number;
+    count(applySkipLimit?: boolean): number;
     fetch(): Array<T>;
     forEach(callback: <T>(doc: T, index: number, cursor: Cursor<T>) => void, thisArg?: any): void;
     map<U>(callback: (doc: T, index: number, cursor: Cursor<T>) => U, thisArg?: any): Array<U>;

--- a/1.3/browser.d.ts
+++ b/1.3/browser.d.ts
@@ -581,8 +581,6 @@ declare module Match {
   var undefined: any;
   var Object: any;
 
-  function Maybe(pattern: any): boolean;
-
   function Optional(pattern: any): boolean;
 
   function ObjectIncluding(dico: any): boolean;
@@ -604,8 +602,6 @@ declare module "meteor/check" {
     var Boolean: any;
     var undefined: any;
     var Object: any;
-
-    function Maybe(pattern: any): boolean;
 
     function Optional(pattern: any): boolean;
 
@@ -1462,7 +1458,7 @@ declare module Mongo {
     removed ? (id: string) : void;
   }
   interface Cursor < T > {
-    count(): number;
+    count(applySkipLimit ? : boolean): number;
     fetch(): Array < T > ;
     forEach(callback: < T > (doc: T, index: number, cursor: Cursor < T > ) => void, thisArg ? : any): void;
     map < U > (callback: (doc: T, index: number, cursor: Cursor < T > ) => U, thisArg ? : any): Array < U > ;
@@ -1571,7 +1567,7 @@ declare module "meteor/mongo" {
       removed ? (id: string) : void;
     }
     interface Cursor < T > {
-      count(): number;
+      count(applySkipLimit ? : boolean): number;
       fetch(): Array < T > ;
       forEach(callback: < T > (doc: T, index: number, cursor: Cursor < T > ) => void, thisArg ? : any): void;
       map < U > (callback: (doc: T, index: number, cursor: Cursor < T > ) => U, thisArg ? : any): Array < U > ;
@@ -1849,6 +1845,15 @@ declare module "meteor/tracker" {
     function nonreactive(func: Function): void;
 
     function onInvalidate(callback: Function): void;
+  }
+}
+declare module Match {
+  function Maybe(pattern: any): boolean;
+}
+
+declare module "meteor/check" {
+  module Match {
+    function Maybe(pattern: any): boolean;
   }
 }
 declare module Meteor {

--- a/1.3/main.d.ts
+++ b/1.3/main.d.ts
@@ -581,8 +581,6 @@ declare module Match {
   var undefined: any;
   var Object: any;
 
-  function Maybe(pattern: any): boolean;
-
   function Optional(pattern: any): boolean;
 
   function ObjectIncluding(dico: any): boolean;
@@ -605,8 +603,6 @@ declare module "meteor/check" {
     var undefined: any;
     var Object: any;
 
-    function Maybe(pattern: any): boolean;
-    
     function Optional(pattern: any): boolean;
 
     function ObjectIncluding(dico: any): boolean;
@@ -1462,7 +1458,7 @@ declare module Mongo {
     removed ? (id: string) : void;
   }
   interface Cursor < T > {
-    count(): number;
+    count(applySkipLimit ? : boolean): number;
     fetch(): Array < T > ;
     forEach(callback: < T > (doc: T, index: number, cursor: Cursor < T > ) => void, thisArg ? : any): void;
     map < U > (callback: (doc: T, index: number, cursor: Cursor < T > ) => U, thisArg ? : any): Array < U > ;
@@ -1571,7 +1567,7 @@ declare module "meteor/mongo" {
       removed ? (id: string) : void;
     }
     interface Cursor < T > {
-      count(): number;
+      count(applySkipLimit ? : boolean): number;
       fetch(): Array < T > ;
       forEach(callback: < T > (doc: T, index: number, cursor: Cursor < T > ) => void, thisArg ? : any): void;
       map < U > (callback: (doc: T, index: number, cursor: Cursor < T > ) => U, thisArg ? : any): Array < U > ;
@@ -2053,6 +2049,15 @@ declare module "meteor/tracker" {
     function nonreactive(func: Function): void;
 
     function onInvalidate(callback: Function): void;
+  }
+}
+declare module Match {
+  function Maybe(pattern: any): boolean;
+}
+
+declare module "meteor/check" {
+  module Match {
+    function Maybe(pattern: any): boolean;
   }
 }
 declare module Meteor {

--- a/1.3/test/test.ts
+++ b/1.3/test/test.ts
@@ -712,3 +712,7 @@ BrowserPolicy.content.allowEval();
 if (Meteor.isDevelopment) {
   Rooms._dropIndex({field: 1});
 }
+
+
+// Covers https://github.com/meteor-typings/meteor/issues/20
+Rooms.find().count(true);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ gulp.task("prep_1_2_browser", function() {
 });
 
 gulp.task("1_2_bundle", function(callback) {
-  exec("cd 1.2 && typings bundle --global -o out",
+  exec("cd 1.2 && typings bundle --global -o out/main.d.ts",
     function(err, stdout, stderr) {
       console.log(stdout);
       console.log(stderr);
@@ -69,7 +69,7 @@ gulp.task("prep_1_3_browser", function() {
 });
 
 gulp.task("1_3_bundle", function(callback) {
-  exec("cd 1.3 && typings bundle --global -o out",
+  exec("cd 1.3 && typings bundle --global -o out/main.d.ts",
     function(err, stdout, stderr) {
       console.log(stdout);
       console.log(stderr);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ gulp.task("prep_1_2_browser", function() {
 });
 
 gulp.task("1_2_bundle", function(callback) {
-  exec("cd 1.2 && typings bundle --ambient -o out",
+  exec("cd 1.2 && typings bundle --global -o out",
     function(err, stdout, stderr) {
       console.log(stdout);
       console.log(stderr);
@@ -69,7 +69,7 @@ gulp.task("prep_1_3_browser", function() {
 });
 
 gulp.task("1_3_bundle", function(callback) {
-  exec("cd 1.3 && typings bundle --ambient -o out",
+  exec("cd 1.3 && typings bundle --global -o out",
     function(err, stdout, stderr) {
       console.log(stdout);
       console.log(stderr);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gulp": "^3.9.1",
     "gulp-change": "^1.0.0",
     "gulp-concat": "^2.6.0",
-    "gulp-filter": "^3.0.0",
+    "gulp-filter": "^4.0.0",
     "gulp-ignore": "^2.0.1",
     "gulp-replace": "^0.5.4",
     "js-beautify": "^1.6.2",
@@ -19,6 +19,6 @@
     "tslint": "^3.8.1",
     "tslint-config-typings": "^0.2.3",
     "typescript": "^1.8.10",
-    "typings": "^0.8.1"
+    "typings": "^1.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "gulp-replace": "^0.5.4",
     "js-beautify": "^1.6.2",
     "run-sequence": "^1.1.5",
-    "tsc": "^1.20150623.0",
     "tslint": "^3.8.1",
     "tslint-config-typings": "^0.2.3",
     "typescript": "^1.8.10",


### PR DESCRIPTION
- Add `applySkipLimit` option in `count` method (https://github.com/meteor/meteor/blob/devel/packages/mongo/mongo_driver.js#L1092).
- Update dependencies including typings 1.x and change options for typings 1.x.
- Run `npm run build+test`, as a result, code related to `Match` is rewritten.