### PR TITLE
Include 'npmRequestOptions' in HTTPRequest

### DIFF
--- a/1.2/browser.d.ts
+++ b/1.2/browser.d.ts
@@ -292,6 +292,7 @@ declare module HTTP {
     headers?: { [id: string]: string };
     timeout?: number;
     followRedirects?: boolean;
+    npmRequestOptions?: Object;
   }
 
   interface HTTPResponse {

--- a/1.2/main.d.ts
+++ b/1.2/main.d.ts
@@ -396,6 +396,7 @@ declare module HTTP {
     headers?: { [id: string]: string };
     timeout?: number;
     followRedirects?: boolean;
+    npmRequestOptions?: Object;
   }
 
   interface HTTPResponse {

--- a/1.2/packages/http.d.ts
+++ b/1.2/packages/http.d.ts
@@ -8,6 +8,7 @@ declare module HTTP {
     headers?: { [id: string]: string };
     timeout?: number;
     followRedirects?: boolean;
+    npmRequestOptions?: Object;
   }
 
   interface HTTPResponse {

--- a/1.3/browser.d.ts
+++ b/1.3/browser.d.ts
@@ -652,6 +652,7 @@ declare module HTTP {
     };
     timeout?: number;
     followRedirects?: boolean;
+    npmRequestOptions?: Object;
   }
 
   interface HTTPResponse {
@@ -702,6 +703,7 @@ declare module "meteor/http" {
       };
       timeout?: number;
       followRedirects?: boolean;
+      npmRequestOptions?: Object;
     }
 
     interface HTTPResponse {

--- a/1.3/main.d.ts
+++ b/1.3/main.d.ts
@@ -880,6 +880,7 @@ declare module HTTP {
     };
     timeout?: number;
     followRedirects?: boolean;
+    npmRequestOptions?: Object;
   }
 
   interface HTTPResponse {
@@ -930,6 +931,7 @@ declare module "meteor/http" {
       };
       timeout?: number;
       followRedirects?: boolean;
+      npmRequestOptions?: Object;
     }
 
     interface HTTPResponse {

--- a/1.4/browser.d.ts
+++ b/1.4/browser.d.ts
@@ -652,6 +652,7 @@ declare module HTTP {
     };
     timeout?: number;
     followRedirects?: boolean;
+    npmRequestOptions?: Object;
   }
 
   interface HTTPResponse {
@@ -702,6 +703,7 @@ declare module "meteor/http" {
       };
       timeout?: number;
       followRedirects?: boolean;
+      npmRequestOptions?: Object;
     }
 
     interface HTTPResponse {

--- a/1.4/main.d.ts
+++ b/1.4/main.d.ts
@@ -880,6 +880,7 @@ declare module HTTP {
     };
     timeout?: number;
     followRedirects?: boolean;
+    npmRequestOptions?: Object;
   }
 
   interface HTTPResponse {
@@ -930,6 +931,7 @@ declare module "meteor/http" {
       };
       timeout?: number;
       followRedirects?: boolean;
+      npmRequestOptions?: Object;
     }
 
     interface HTTPResponse {


### PR DESCRIPTION
This commit includes the npmRequestOptions key on the HTTP.HTTPRequest object. It was previously available in the HTTP.call method, but should be available on the HTTPRequest object as well.