### PR TITLE
Added name type "null" to CollectionStatic

### DIFF
--- a/1.2/packages/mongo.d.ts
+++ b/1.2/packages/mongo.d.ts
@@ -11,7 +11,7 @@ declare module Mongo {
 
   var Collection: CollectionStatic;
   interface CollectionStatic {
-    new <T>(name: string, options?: {
+    new <T>(name: string | null, options?: {
       connection?: Object;
       idGeneration?: string;
       transform?: Function;


### PR DESCRIPTION
Based on the docs on https://docs.meteor.com/api/collections.html#Mongo-Collection
Local collections are declared with name `null`.